### PR TITLE
Adding support for multisig wallet API (CIP-106)

### DIFF
--- a/packages/core-types/src/global.ts
+++ b/packages/core-types/src/global.ts
@@ -14,6 +14,13 @@ export type WalletApi = {
   ): Promise<{ signature: string; key: string }>;
   submitTx(tx: string): Promise<string>;
   getCollateral(): Promise<string[]>;
+  cip106? : {
+    submitUnsignedTx(tx : string) : Promise<string>;
+    getCollateralAddress() : Promise<string>;
+    getScriptRequirements() : Promise<string>,
+    getScript: () => Promise<string>,
+    getCompletedTx: (txId : string) =>  Promise<string>
+  }
   experimental: {
     getCollateral(): Promise<string[]>;
     on(eventName: string, callback: (...args: unknown[]) => void): void;

--- a/packages/core-types/src/global.ts
+++ b/packages/core-types/src/global.ts
@@ -17,7 +17,7 @@ export type WalletApi = {
   cip106? : {
     submitUnsignedTx(tx : string) : Promise<string>;
     getCollateralAddress() : Promise<string>;
-    getScriptRequirements() : Promise<string>,
+    getScriptRequirements() : Promise<any[]>,
     getScript: () => Promise<string>,
     getCompletedTx: (txId : string) =>  Promise<string>
   }

--- a/packages/core-types/src/types.ts
+++ b/packages/core-types/src/types.ts
@@ -1,4 +1,5 @@
 import * as CML from "@dcspark/cardano-multiplatform-lib-nodejs";
+
 type CostModel = Record<string, number>;
 
 export type CostModels = Record<PlutusVersion, CostModel>;
@@ -168,6 +169,7 @@ export interface ExternalWallet {
 
 export type SignedMessage = { signature: string; key: string };
 
+
 export interface Wallet {
   address(): Promise<Address>;
   rewardAddress(): Promise<RewardAddress | null>;
@@ -180,6 +182,13 @@ export interface Wallet {
     payload: Payload,
   ): Promise<SignedMessage>;
   submitTx(signedTx: Transaction): Promise<TxHash>;
+}
+
+export interface MultisigWallet extends Wallet {
+  submitUnsignedTx(tx: CML.Transaction): Promise< string>;
+  getCollateralAddress(): Promise<Address>;
+  getScriptRequirements(): Promise<Script[]>;
+  getScript(): Promise<Script>;
 }
 
 /** JSON object */

--- a/packages/core-types/src/types.ts
+++ b/packages/core-types/src/types.ts
@@ -187,7 +187,7 @@ export interface Wallet {
 export interface MultisigWallet extends Wallet {
   submitUnsignedTx(tx: CML.Transaction): Promise< string>;
   getCollateralAddress(): Promise<Address>;
-  getScriptRequirements(): Promise<Script[]>;
+  getScriptRequirements(): Promise<any[]>;
   getScript(): Promise<Script>;
 }
 

--- a/packages/lucid/src/lucid-evolution/LucidEvolution.ts
+++ b/packages/lucid/src/lucid-evolution/LucidEvolution.ts
@@ -37,6 +37,7 @@ export type LucidEvolution = {
     fromSeed: (seed: string) => void;
     fromPrivateKey: (privateKey: PrivateKey) => void;
     fromAPI: (walletAPI: WalletApi) => void;
+    fromCip106Api: (walletAPI: WalletApi) => void;
     fromAddress: (address: string, utxos: UTxO[]) => void;
   };
   currentSlot: () => number;
@@ -109,6 +110,9 @@ export const Lucid = async (
         );
       },
       fromAPI: (walletAPI: WalletApi) => {
+        config.wallet = makeWalletFromAPI(config.provider, walletAPI);
+      },
+      fromCip106Api: (walletAPI: WalletApi) => {
         config.wallet = makeWalletFromAPI(config.provider, walletAPI);
       },
       fromAddress: (address: string, utxos: UTxO[]) => {

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -269,8 +269,8 @@ export const makeWalletFromCip106API = (
       const script = await api.cip106.getScript();
       return script;
     },
+  };
 };
-
 
 
 export const makeWalletFromAPI = (

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -254,19 +254,19 @@ export const makeWalletFromCip106API = (
       return txHash;
     },
     submitUnsignedTx: async (tx: CML.Transaction): Promise< string> => {
-      const txId = await api.cip106?.submitUnsignedTx(toHex(tx.to_cbor_bytes()));
+      const txId = await api.cip106?.submitUnsignedTx(toHex(tx.to_cbor_bytes())) || "";
       return txId;
     },
     getCollateralAddress: async (): Promise<Address> => {
-      const collateralAddress = await api.cip106?.getCollateralAddress();
+      const collateralAddress = await api.cip106?.getCollateralAddress() || "";
       return collateralAddress;
     },
     getScriptRequirements: async (): Promise<any[]> => {
-      const scriptRequirements = await api.cip106?.getScriptRequirements();
+      const scriptRequirements = await api.cip106?.getScriptRequirements() || [];
       return scriptRequirements;
     },
     getScript: async () : Promise<string> => {
-      const script = await api.cip106?.getScript();
+      const script = await api.cip106?.getScript() || "";
       return script;
     },
   };

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -239,7 +239,7 @@ export const makeWalletFromCip106API = (
         : { poolId: null, rewards: 0n };
     },
     signTx: async (tx: CML.Transaction): Promise<CML.TransactionWitnessSet> => {
-      const txId = await api.cip106.submitUnsignedTx(toHex(tx.to_cbor_bytes()));
+      const txId = await api.cip106?.submitUnsignedTx(toHex(tx.to_cbor_bytes()));
       
       throw new Error("Not supported for CIP-106 wallets.");
     },
@@ -254,19 +254,19 @@ export const makeWalletFromCip106API = (
       return txHash;
     },
     submitUnsignedTx: async (tx: CML.Transaction): Promise< string> => {
-      const txId = await api.cip106.submitUnsignedTx(toHex(tx.to_cbor_bytes()));
+      const txId = await api.cip106?.submitUnsignedTx(toHex(tx.to_cbor_bytes()));
       return txId;
     },
     getCollateralAddress: async (): Promise<Address> => {
-      const collateralAddress = await api.cip106.getCollateralAddress();
+      const collateralAddress = await api.cip106?.getCollateralAddress();
       return collateralAddress;
     },
     getScriptRequirements: async (): Promise<any[]> => {
-      const scriptRequirements = await api.cip106.getScriptRequirements();
+      const scriptRequirements = await api.cip106?.getScriptRequirements();
       return scriptRequirements;
     },
     getScript: async () : Promise<string> => {
-      const script = await api.cip106.getScript();
+      const script = await api.cip106?.getScript();
       return script;
     },
   };

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -14,6 +14,7 @@ import {
   Wallet,
   WalletApi,
   MultisigWallet,
+  Script,
 } from "@lucid-evolution/core-types";
 import { fromHex, toHex } from "@lucid-evolution/core-utils";
 import {
@@ -265,8 +266,8 @@ export const makeWalletFromCip106API = (
       const scriptRequirements = await api.cip106?.getScriptRequirements() || [];
       return scriptRequirements;
     },
-    getScript: async () : Promise<string> => {
-      const script = await api.cip106?.getScript() || "";
+    getScript: async () : Promise<Script> => {
+      const script = { type: "Native", script: await api.cip106?.getScript()  || "" }; 
       return script;
     },
   };

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -267,7 +267,7 @@ export const makeWalletFromCip106API = (
       return scriptRequirements;
     },
     getScript: async () : Promise<Script> => {
-      const script = { type: "Native", script: await api.cip106?.getScript()  || "" }; 
+      const script = { type: "Native", script: await api.cip106?.getScript()  || "" } as Script; 
       return script;
     },
   };


### PR DESCRIPTION
WARNING: Untested, this is not yet ready to merge!

I have created the initial layout for this feat, I am opening a pull request to get feedback on the last part I need to complete before staring with testing.

to submit a transaction the developers building against CIP-106 need to attach the script, and the correct Key Hashes as "extra signers" 

To do this I have 2 options in mind : 
A) create a getRefTransaction() <TxBuilder>, that will return a tx complete with all the requirements that the dev can then expand on or compose with all the other tx they want to perform. 

B) During tx.complete()  add a check if the Wallet is of type MultisigApi and attach all the required parameters before finalizing. 

B seems to be the path with the least amount of friction as devs would be able to use it almost exactly how they would a regular wallet. 